### PR TITLE
Ready for multiple window on iPadOS

### DIFF
--- a/FireTodo-w-SwiftUI/Sources/SceneDelegate.swift
+++ b/FireTodo-w-SwiftUI/Sources/SceneDelegate.swift
@@ -11,7 +11,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        let window = UIWindow(frame: UIScreen.main.bounds)
+        let window = UIWindow(windowScene: scene as! UIWindowScene)
         window.rootViewController = UIHostingController(
             rootView: RootView().environmentObject(UserData())
         )


### PR DESCRIPTION
If you check `Supports multiple windows` in General tab, apps has only black screen.
So you should set `windowScene` in initialization of `UIWIndow`.